### PR TITLE
[feat] MySQL 기반 멀티턴 대화 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-model-chat-memory-repository-jdbc'
     implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -64,7 +65,7 @@ tasks.named('test') {
 def querydslDir = "$buildDir/generated/querydsl"
 
 sourceSets {
-    main.java.srcDirs += [ querydslDir ]
+    main.java.srcDirs += [querydslDir]
 }
 dependencyManagement {
     imports {

--- a/src/main/java/com/ureca/yoajungserver/chatbot/controller/TestController.java
+++ b/src/main/java/com/ureca/yoajungserver/chatbot/controller/TestController.java
@@ -1,15 +1,23 @@
 package com.ureca.yoajungserver.chatbot.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class TestController {
 
-    @GetMapping("/test")
-    public String testBadWord(@RequestParam("question") String question) {
+    private final ChatClient chatClient;
 
-        return question;
+    @GetMapping("/test")
+    public String testBadWord(@RequestParam("question") String question, @RequestParam("userId") Long userId) {
+        return chatClient.prompt().user(question)
+                .advisors(advisorSpec -> advisorSpec.param(ChatMemory.CONVERSATION_ID, userId))
+                .call()
+                .content();
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/common/config/AIConfig.java
+++ b/src/main/java/com/ureca/yoajungserver/common/config/AIConfig.java
@@ -1,14 +1,32 @@
 package com.ureca.yoajungserver.common.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.chat.memory.repository.jdbc.JdbcChatMemoryRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class AIConfig {
 
+    private final JdbcChatMemoryRepository jdbcChatMemoryRepository;
+
     @Bean
-    public ChatClient chatClient(ChatClient.Builder chatClientBuilder) {
-        return chatClientBuilder.build();
+    public ChatMemory chatMemory() {
+        return MessageWindowChatMemory.builder()
+                .chatMemoryRepository(jdbcChatMemoryRepository)
+                .maxMessages(20)
+                .build();
+    }
+
+    @Bean
+    public ChatClient chatClient(ChatClient.Builder chatClientBuilder, ChatMemory chatMemory) {
+        return chatClientBuilder
+                .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
+                .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,9 @@ spring:
         options:
           model: gpt-4o
           temperature: 0.4
+    chat:
+      memory:
+        repository:
+          jdbc:
+            initialize-schema: always
+            platform: mariadb


### PR DESCRIPTION
## 개요
<!-- 이 PR이 어떤 기능/수정/버그 해결 등을 위한 것인지 간단히 설명해주세요. -->
- 멀티턴 기능을 MySQL 기반으로 구현하였습니다.
- 사용자의 `conversationId`를 기준으로 이전 대화 히스토리를 불러옵니다.

## 변경 사항
<!-- 주요 변경 사항을 bullet로 정리해주세요 -->
- JdbcChatMemoryRepository 기반 대화 저장소 설정
- MessageWindowChatMemory를 통해 최근 20개 대화 유지