### PR TITLE
[feat] ChatMemory 엔티티 추가 및 테이블 이름 전략 수정

### DIFF
--- a/src/main/java/com/ureca/yoajungserver/chatbot/entity/ChatMemory.java
+++ b/src/main/java/com/ureca/yoajungserver/chatbot/entity/ChatMemory.java
@@ -1,0 +1,34 @@
+package com.ureca.yoajungserver.chatbot.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "SPRING_AI_CHAT_MEMORY" )
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMemory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "conversation_id", length = 36, nullable = false)
+    private String conversationId;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "type", length = 10, nullable = false)
+    private String type;
+
+    @Column(name = "timestamp", nullable = false)
+    private LocalDateTime timestamp;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 개요
<!-- 이 PR이 어떤 기능/수정/버그 해결 등을 위한 것인지 간단히 설명해주세요. -->
- 챗봇 대화 기록 저장을 위한 `ChatMemory` 엔티티를 생성했습니다
- 테이블 이름 생성 전략을 변경했습니다.