### PR TITLE
[Feat] 요금제 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/ureca/yoajungserver/common/BaseCode.java
+++ b/src/main/java/com/ureca/yoajungserver/common/BaseCode.java
@@ -31,6 +31,8 @@ public enum BaseCode {
 
     // Plan
     PLAN_DETAIL_SUCCESS("FIND_PLAN_DETAIL_200", HttpStatus.OK, "요금제 상세 조회에 성공했습니다."),
+    PLAN_BENEFIT_SUCCESS("FIND_PLAN_BENEFIT_200", HttpStatus.OK, "요금제 혜택 조회에 성공했습니다."),
+    PLAN_PRODUCT_SUCCESS("FIND_PLAN_PRODUCT_200", HttpStatus.OK, "요금제 상품 조회에 성공했습니다."),
     PLAN_LIST_SUCCESS("READ_PLAN_LIST_200", HttpStatus.OK, "요금제 목록 조회에 성공했습니다."),
     PLAN_NOT_FOUND("NOT_FOUND_PLAN_404", HttpStatus.NOT_FOUND, "해당 요금제를 찾을 수 없습니다."),
 

--- a/src/main/java/com/ureca/yoajungserver/plan/advice/PlanControllerAdvice.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/advice/PlanControllerAdvice.java
@@ -1,0 +1,16 @@
+package com.ureca.yoajungserver.plan.advice;
+
+import com.ureca.yoajungserver.common.ApiResponse;
+import com.ureca.yoajungserver.review.exception.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class PlanControllerAdvice {
+    @ExceptionHandler(PlanNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handlePlanNotFoundException(PlanNotFoundException e) {
+        return ResponseEntity.status(e.getBaseCode().getStatus())
+                .body(ApiResponse.ok(e.getBaseCode()));
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
@@ -1,10 +1,7 @@
 package com.ureca.yoajungserver.plan.controller;
 
 import com.ureca.yoajungserver.common.ApiResponse;
-import com.ureca.yoajungserver.plan.dto.response.DetailPlanBenefitResponse;
-import com.ureca.yoajungserver.plan.dto.response.DetailPlanProductResponse;
-import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
-import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
+import com.ureca.yoajungserver.plan.dto.response.*;
 import com.ureca.yoajungserver.plan.service.PlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +29,7 @@ public class PlanController {
 
     @GetMapping("/{planId}")
     public ResponseEntity<ApiResponse<?>> getDetailPlan(@PathVariable(value = "planId") Long planId) {
-        DetailPlanProductResponse responses = planService.getDetailPlanProducts(planId);
+        DetailPlanResponse responses = planService.getDetailPlan(planId);
         return ResponseEntity
                 .status(PLAN_DETAIL_SUCCESS.getStatus())
                 .body(ApiResponse.of(PLAN_DETAIL_SUCCESS, responses));

--- a/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
@@ -1,6 +1,7 @@
 package com.ureca.yoajungserver.plan.controller;
 
 import com.ureca.yoajungserver.common.ApiResponse;
+import com.ureca.yoajungserver.plan.dto.response.DetailPlanBenefitResponse;
 import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
 import com.ureca.yoajungserver.plan.service.PlanService;
@@ -8,10 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.ureca.yoajungserver.common.BaseCode.PLAN_LIST_SUCCESS;
-import static com.ureca.yoajungserver.common.BaseCode.PLAN_PRODUCT_SUCCESS;
-
 import java.util.List;
+
+import static com.ureca.yoajungserver.common.BaseCode.*;
 
 @RestController
 @RequestMapping("api/plan")
@@ -35,5 +35,13 @@ public class PlanController {
         return ResponseEntity
                 .status(PLAN_PRODUCT_SUCCESS.getStatus())
                 .body(ApiResponse.of(PLAN_PRODUCT_SUCCESS, responses));
+    }
+
+    @GetMapping("/benefits/{planId}")
+    public ResponseEntity<ApiResponse<?>> getDetailPlanBenefit(@PathVariable(value = "planId") Long planId) {
+        DetailPlanBenefitResponse responses = planService.getDetailPlanBenefit(planId);
+        return ResponseEntity
+                .status(PLAN_BENEFIT_SUCCESS.getStatus())
+                .body(ApiResponse.of(PLAN_BENEFIT_SUCCESS, responses));
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
@@ -1,16 +1,15 @@
 package com.ureca.yoajungserver.plan.controller;
 
 import com.ureca.yoajungserver.common.ApiResponse;
+import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
 import com.ureca.yoajungserver.plan.service.PlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.ureca.yoajungserver.common.BaseCode.PLAN_LIST_SUCCESS;
+import static com.ureca.yoajungserver.common.BaseCode.PLAN_PRODUCT_SUCCESS;
 
 import java.util.List;
 
@@ -28,5 +27,13 @@ public class PlanController {
         return ResponseEntity
                 .status(PLAN_LIST_SUCCESS.getStatus())
                 .body(ApiResponse.of(PLAN_LIST_SUCCESS, responses));
+    }
+
+    @GetMapping("/products/{planId}")
+    public ResponseEntity<ApiResponse<?>> getListPlanProduct(@PathVariable(value = "planId") Long planId) {
+        List<DetailProductDto> responses = planService.getListPlanProducts(planId);
+        return ResponseEntity
+                .status(PLAN_PRODUCT_SUCCESS.getStatus())
+                .body(ApiResponse.of(PLAN_PRODUCT_SUCCESS, responses));
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/controller/PlanController.java
@@ -2,6 +2,7 @@ package com.ureca.yoajungserver.plan.controller;
 
 import com.ureca.yoajungserver.common.ApiResponse;
 import com.ureca.yoajungserver.plan.dto.response.DetailPlanBenefitResponse;
+import com.ureca.yoajungserver.plan.dto.response.DetailPlanProductResponse;
 import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
 import com.ureca.yoajungserver.plan.service.PlanService;
@@ -29,9 +30,17 @@ public class PlanController {
                 .body(ApiResponse.of(PLAN_LIST_SUCCESS, responses));
     }
 
+    @GetMapping("/{planId}")
+    public ResponseEntity<ApiResponse<?>> getDetailPlan(@PathVariable(value = "planId") Long planId) {
+        DetailPlanProductResponse responses = planService.getDetailPlanProducts(planId);
+        return ResponseEntity
+                .status(PLAN_DETAIL_SUCCESS.getStatus())
+                .body(ApiResponse.of(PLAN_DETAIL_SUCCESS, responses));
+    }
+
     @GetMapping("/products/{planId}")
-    public ResponseEntity<ApiResponse<?>> getListPlanProduct(@PathVariable(value = "planId") Long planId) {
-        List<DetailProductDto> responses = planService.getListPlanProducts(planId);
+    public ResponseEntity<ApiResponse<?>> getDetailPlanProduct(@PathVariable(value = "planId") Long planId) {
+        DetailPlanProductResponse responses = planService.getDetailPlanProducts(planId);
         return ResponseEntity
                 .status(PLAN_PRODUCT_SUCCESS.getStatus())
                 .body(ApiResponse.of(PLAN_PRODUCT_SUCCESS, responses));

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailBenefitDto.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailBenefitDto.java
@@ -1,0 +1,31 @@
+package com.ureca.yoajungserver.plan.dto.response;
+
+import com.ureca.yoajungserver.plan.entity.Benefit;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DetailBenefitDto {
+    private String name;
+    private String description;
+    private Integer voiceLimit;
+    private Integer smsLimit;
+    private Integer discountAmount;
+
+    public static DetailBenefitDto fromBenefit(Benefit benefit) {
+        if (benefit == null) {
+            return null;
+        }
+
+        return DetailBenefitDto.builder()
+                .name(benefit.getName())
+                .description(benefit.getDescription())
+                .voiceLimit(benefit.getVoiceLimit())
+                .smsLimit(benefit.getSmsLimit())
+                .discountAmount(benefit.getDiscountAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanBenefitResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanBenefitResponse.java
@@ -1,0 +1,16 @@
+package com.ureca.yoajungserver.plan.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DetailPlanBenefitResponse {
+    private DetailBenefitDto voice;
+    private DetailBenefitDto sms;
+    private DetailBenefitDto media;
+    private DetailBenefitDto smartDevice;
+    private DetailBenefitDto base;
+    private DetailBenefitDto premium;
+    private DetailBenefitDto other;
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanProductResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanProductResponse.java
@@ -1,6 +1,5 @@
 package com.ureca.yoajungserver.plan.dto.response;
 
-import com.ureca.yoajungserver.plan.entity.Benefit;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanProductResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanProductResponse.java
@@ -1,0 +1,14 @@
+package com.ureca.yoajungserver.plan.dto.response;
+
+import com.ureca.yoajungserver.plan.entity.Benefit;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DetailPlanProductResponse {
+    private List<DetailProductDto> media;
+    private List<DetailProductDto> premium;
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailPlanResponse.java
@@ -1,0 +1,29 @@
+package com.ureca.yoajungserver.plan.dto.response;
+
+import com.ureca.yoajungserver.plan.entity.Plan;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DetailPlanResponse {
+    private Long planId;
+    private String networkType;
+    private Integer basePrice;
+    private Integer dataAllowance;
+    private Integer tetheringSharingAllowance;
+    private Integer speedAfterLimit;
+    private String description;
+
+    public static DetailPlanResponse fromPlan(Plan plan) {
+        return DetailPlanResponse.builder()
+                .planId(plan.getId())
+                .networkType(plan.getNetworkType().name())
+                .basePrice(plan.getBasePrice())
+                .dataAllowance(plan.getDataAllowance())
+                .tetheringSharingAllowance(plan.getTetheringSharingAllowance())
+                .speedAfterLimit(plan.getSpeedAfterLimit())
+                .description(plan.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailProductDto.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/DetailProductDto.java
@@ -1,0 +1,26 @@
+package com.ureca.yoajungserver.plan.dto.response;
+
+import com.ureca.yoajungserver.plan.entity.Product;
+import com.ureca.yoajungserver.plan.entity.ProductCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DetailProductDto {
+    private String name;
+    private String description;
+    private String productImage;
+    private ProductCategory productCategory;
+
+    public static DetailProductDto fromProduct(Product product) {
+        return DetailProductDto.builder()
+                .name(product.getName())
+                .description(product.getDescription())
+                .productImage(product.getProductImage())
+                .productCategory(product.getProductCategory())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/ListPlanResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/ListPlanResponse.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 @Getter
 @Builder
-@AllArgsConstructor
 public class ListPlanResponse {
     private Long planId;
     private String networkType;

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/ListPlanResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/ListPlanResponse.java
@@ -18,10 +18,10 @@ public class ListPlanResponse {
     private Integer tetheringSharingAllowance;
     private Integer speedAfterLimit;
     private String description;
-    private List<ListServiceDto> services;
+    private List<ListProductDto> products;
     private List<ListBenefitDto> benefits;
 
-    public static ListPlanResponse fromPlan(Plan plan, List<ListServiceDto> services, List<ListBenefitDto> benefits) {
+    public static ListPlanResponse fromPlan(Plan plan, List<ListProductDto> products, List<ListBenefitDto> benefits) {
         return ListPlanResponse.builder()
                 .planId(plan.getId())
                 .networkType(plan.getNetworkType().name())
@@ -30,7 +30,7 @@ public class ListPlanResponse {
                 .tetheringSharingAllowance(plan.getTetheringSharingAllowance())
                 .speedAfterLimit(plan.getSpeedAfterLimit())
                 .description(plan.getDescription())
-                .services(services)
+                .products(products)
                 .benefits(benefits)
                 .build();
     }

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/ListProductDto.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/ListProductDto.java
@@ -8,14 +8,14 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class ListServiceDto {
+public class ListProductDto {
     private String name;
-    private String serviceImage;
+    private String productImage;
 
-    public static ListServiceDto fromService(Product service) {
-        return ListServiceDto.builder()
-                .name(service.getName())
-                .serviceImage(service.getServiceImage())
+    public static ListProductDto fromService(Product product) {
+        return ListProductDto.builder()
+                .name(product.getName())
+                .productImage(product.getProductImage())
                 .build();
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/entity/Product.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/entity/Product.java
@@ -28,14 +28,14 @@ public class Product extends BaseTimeEntity {
     private String description;
 
     @Column(nullable = false)
-    private String serviceImage;
+    private String productImage;
 
     @Builder
-    private Product(String name, ProductType productType, ProductCategory productCategory, String description, String serviceImage) {
+    private Product(String name, ProductType productType, ProductCategory productCategory, String description, String productImage) {
         this.name = name;
         this.productType = productType;
         this.productCategory = productCategory;
         this.description = description;
-        this.serviceImage = serviceImage;
+        this.productImage = productImage;
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/exception/PlanNotFoundException.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/exception/PlanNotFoundException.java
@@ -1,0 +1,15 @@
+package com.ureca.yoajungserver.plan.exception;
+
+import com.ureca.yoajungserver.common.BaseCode;
+import com.ureca.yoajungserver.common.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class PlanNotFoundException extends BusinessException {
+
+    private final BaseCode baseCode;
+    public PlanNotFoundException(BaseCode baseCode) {
+        super(baseCode);
+        this.baseCode = baseCode;
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/BenefitRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/BenefitRepository.java
@@ -1,7 +1,0 @@
-package com.ureca.yoajungserver.plan.repository;
-
-import com.ureca.yoajungserver.plan.entity.Benefit;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface BenefitRepository extends JpaRepository<Benefit, Long> {
-}

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/PlanBenefitRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/PlanBenefitRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.yoajungserver.plan.repository;
+
+import com.ureca.yoajungserver.plan.entity.PlanBenefit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PlanBenefitRepository extends JpaRepository<PlanBenefit, Long> {
+    List<PlanBenefit> findByPlanId(Long planId);
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/PlanBenefitRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/PlanBenefitRepository.java
@@ -1,10 +1,14 @@
 package com.ureca.yoajungserver.plan.repository;
 
 import com.ureca.yoajungserver.plan.entity.PlanBenefit;
+import com.ureca.yoajungserver.plan.entity.PlanProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PlanBenefitRepository extends JpaRepository<PlanBenefit, Long> {
-    List<PlanBenefit> findByPlanId(Long planId);
+    @Query("select pb from PlanBenefit pb join fetch pb.benefit where pb.plan.id = :planId")
+    List<PlanBenefit> findByPlanIdWithBenefit(@Param("planId") Long planId);
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/PlanProductRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/PlanProductRepository.java
@@ -2,9 +2,12 @@ package com.ureca.yoajungserver.plan.repository;
 
 import com.ureca.yoajungserver.plan.entity.PlanProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PlanProductRepository extends JpaRepository<PlanProduct, Long> {
-    List<PlanProduct> findByPlanId(Long planId);
+    @Query("select pp from PlanProduct pp join fetch pp.product where pp.plan.id = :planId")
+    List<PlanProduct> findByPlanIdWithProduct(@Param("planId") Long planId);
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/PlanProductRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/PlanProductRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.yoajungserver.plan.repository;
+
+import com.ureca.yoajungserver.plan.entity.PlanProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PlanProductRepository extends JpaRepository<PlanProduct, Long> {
+    List<PlanProduct> findByPlanId(Long planId);
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/ProductRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/ProductRepository.java
@@ -1,7 +1,0 @@
-package com.ureca.yoajungserver.plan.repository;
-
-import com.ureca.yoajungserver.plan.entity.Product;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ProductRepository extends JpaRepository<Product, Long> {
-}

--- a/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
@@ -1,12 +1,13 @@
 package com.ureca.yoajungserver.plan.service;
 
+import com.ureca.yoajungserver.plan.dto.response.DetailPlanBenefitResponse;
 import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface PlanService {
     List<ListPlanResponse> getListPlan(int page, int size);
     List<DetailProductDto> getListPlanProducts(Long planId);
+    DetailPlanBenefitResponse getDetailPlanBenefit(Long planId);
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
@@ -2,12 +2,14 @@ package com.ureca.yoajungserver.plan.service;
 
 import com.ureca.yoajungserver.plan.dto.response.DetailPlanBenefitResponse;
 import com.ureca.yoajungserver.plan.dto.response.DetailPlanProductResponse;
+import com.ureca.yoajungserver.plan.dto.response.DetailPlanResponse;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
 
 import java.util.List;
 
 public interface PlanService {
     List<ListPlanResponse> getListPlan(int page, int size);
+    DetailPlanResponse getDetailPlan(Long planId);
     DetailPlanProductResponse getDetailPlanProducts(Long planId);
     DetailPlanBenefitResponse getDetailPlanBenefit(Long planId);
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
@@ -1,5 +1,6 @@
 package com.ureca.yoajungserver.plan.service;
 
+import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -7,4 +8,5 @@ import java.util.List;
 
 public interface PlanService {
     List<ListPlanResponse> getListPlan(int page, int size);
+    List<DetailProductDto> getListPlanProducts(Long planId);
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/service/PlanService.java
@@ -1,13 +1,13 @@
 package com.ureca.yoajungserver.plan.service;
 
 import com.ureca.yoajungserver.plan.dto.response.DetailPlanBenefitResponse;
-import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
+import com.ureca.yoajungserver.plan.dto.response.DetailPlanProductResponse;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
 
 import java.util.List;
 
 public interface PlanService {
     List<ListPlanResponse> getListPlan(int page, int size);
-    List<DetailProductDto> getListPlanProducts(Long planId);
+    DetailPlanProductResponse getDetailPlanProducts(Long planId);
     DetailPlanBenefitResponse getDetailPlanBenefit(Long planId);
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/service/PlanServiceImpl.java
@@ -54,6 +54,14 @@ public class PlanServiceImpl implements PlanService {
     }
 
     @Override
+    public DetailPlanResponse getDetailPlan(Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanNotFoundException(PLAN_NOT_FOUND));
+
+        return DetailPlanResponse.fromPlan(plan);
+    }
+
+    @Override
     public DetailPlanProductResponse getDetailPlanProducts(Long planId) {
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new PlanNotFoundException(PLAN_NOT_FOUND));

--- a/src/main/java/com/ureca/yoajungserver/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/service/PlanServiceImpl.java
@@ -1,11 +1,15 @@
 package com.ureca.yoajungserver.plan.service;
 
+import com.ureca.yoajungserver.plan.dto.response.DetailProductDto;
 import com.ureca.yoajungserver.plan.dto.response.ListBenefitDto;
 import com.ureca.yoajungserver.plan.dto.response.ListPlanResponse;
-import com.ureca.yoajungserver.plan.dto.response.ListServiceDto;
+import com.ureca.yoajungserver.plan.dto.response.ListProductDto;
 import com.ureca.yoajungserver.plan.entity.Plan;
 import com.ureca.yoajungserver.plan.entity.PlanBenefit;
+import com.ureca.yoajungserver.plan.entity.PlanProduct;
+import com.ureca.yoajungserver.plan.repository.PlanProductRepository;
 import com.ureca.yoajungserver.plan.repository.PlanRepository;
+import com.ureca.yoajungserver.plan.exception.PlanNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,11 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.ureca.yoajungserver.common.BaseCode.PLAN_NOT_FOUND;
+
 @Repository
 @RequiredArgsConstructor
 public class PlanServiceImpl implements PlanService {
 
     private final PlanRepository planRepository;
+    private final PlanProductRepository planProductRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -37,13 +44,25 @@ public class PlanServiceImpl implements PlanService {
                             .map(ListBenefitDto::fromBenefit)
                             .collect(Collectors.toList());
 
-                    List<ListServiceDto> serviceDtos = plan.getPlanProducts().stream()
-                            .map(com.ureca.yoajungserver.plan.entity.PlanProduct::getProduct)
-                            .map(ListServiceDto::fromService)
+                    List<ListProductDto> serviceDtos = plan.getPlanProducts().stream()
+                            .map(PlanProduct::getProduct)
+                            .map(ListProductDto::fromService)
                             .collect(Collectors.toList());
 
                     return ListPlanResponse.fromPlan(plan, serviceDtos, benefitDtos);
                 })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<DetailProductDto> getListPlanProducts(Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanNotFoundException(PLAN_NOT_FOUND));
+
+        List<PlanProduct> planProducts = planProductRepository.findByPlanId(plan.getId());
+
+        return planProducts.stream()
+                .map(product -> DetailProductDto.fromProduct(product.getProduct()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     password: ${MYSQL_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+#      ddl-auto: update
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:


### PR DESCRIPTION
## 개요
요금제와 연관된 상세 정보 조회 기능 추가

## 변경 사항
- 예외 처리 로직 추가
- fetch join 을 활용하여 N+1 개선, 2-3 회 쿼리로 조회 가능 -> 추후 dto 프로젝션 활용 고민
- Benefit, Product 타입 별로 응답

## 스크린샷
![detail](https://github.com/user-attachments/assets/e107a379-a691-417f-91d7-cc57329fb951)

