### PR TITLE
[feat] 유저 성향 최초 조회, 수정 삭제

### DIFF
--- a/src/main/java/com/ureca/yoajungserver/common/BaseCode.java
+++ b/src/main/java/com/ureca/yoajungserver/common/BaseCode.java
@@ -17,7 +17,7 @@ public enum BaseCode {
 
     // user/singup
     USER_SIGNUP_SUCCESS("USER_SIGNUP_SUCCESS_201", HttpStatus.CREATED, "회원가입 됐습니다"),
-    USER_NOT_FOUND("NOT_FOUND_USER_404", HttpStatus.NOT_FOUND, "유저가 없습니다"),
+    USER_NOT_FOUND("USER_NOT_FOUND_404", HttpStatus.NOT_FOUND, "유저가 없습니다"),
     USER_DUPLICATED_EMAIL("USER_DUPLICATED_EMAIL_409", HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     USER_DUPLICATED_PHONE_NUMBER("USER_DUPLICATED_PHONE_NUMBER_409", HttpStatus.CONFLICT, "이미 가입된 전화번호입니다"),
 
@@ -26,6 +26,13 @@ public enum BaseCode {
     USER_LOGIN_FAIL("USER_LOGIN_FAIL_401", HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     USER_LOGOUT_SUCCESS("USER_LOGOUT_SUCCESS_200", HttpStatus.OK, "로그아웃에 성공했습니다."),
     USER_SESSION_EXPIRED("USER_SESSION_EXPIRED_401", HttpStatus.UNAUTHORIZED, "세션이 만료됐습니다. 다시 로그인해주세요."),
+
+    // tendency
+    TENDENCY_ALREADY_EXISTS("TENDENCY_ALREADY_EXISTS_409", HttpStatus.CONFLICT, "이미 등록된 성향입니다"),
+    TENDENCY_CREATED("TENDENCY_CREATED_201", HttpStatus.CREATED, "성향을 등록했습니다"),
+    TENDENCY_UPDATED("TENDENCY_UPDATED_200", HttpStatus.OK, "성향을 수정했습니다"),
+    TENDENCY_FIND_SUCCESS("TENDENCY_SUCCESS_200", HttpStatus.OK, "성향정보 조회했습니다"),
+    TENDENCY_NOT_FOUND("TENDENCY_NOT_FOUND_404", HttpStatus.NOT_FOUND, "성향이 없습니다"),
 
     // pw
     PASSWORD_RESET_LINK_SENT("PASSWORD_RESET_LINK_SENT_200", HttpStatus.OK, "비밀번호 재설정 링크가 전송됐습니다"),

--- a/src/main/java/com/ureca/yoajungserver/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/ureca/yoajungserver/common/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.ureca.yoajungserver.common;
 
 import com.ureca.yoajungserver.common.exception.BusinessException;
-import com.ureca.yoajungserver.user.exception.EmailSendFailedException;
 import jakarta.transaction.SystemException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.redis.RedisConnectionFailureException;
@@ -48,12 +47,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.ok(BaseCode.USER_LOGIN_FAIL));
     }// 로그인 실패
-
-    @ExceptionHandler(EmailSendFailedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleEmailSendFailed(EmailSendFailedException exception) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.ok(BaseCode.EMAIL_SEND_FAILED));
-    }
 
     @ExceptionHandler(RedisConnectionFailureException.class)
     public ResponseEntity<ApiResponse<Void>> handlerRedisFaulrue(RedisConnectionFailureException exception) {

--- a/src/main/java/com/ureca/yoajungserver/user/controller/TendencyController.java
+++ b/src/main/java/com/ureca/yoajungserver/user/controller/TendencyController.java
@@ -11,10 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,5 +40,14 @@ public class TendencyController {
         Tendency tendency = tendencyService.registerTendency(userDetails.getUsername(), request);
         TendencyResponse response = TendencyResponse.fromEntity(tendency);
         return ResponseEntity.ok(ApiResponse.of(BaseCode.STATUS_CREATED, response));
+    }
+
+    @PutMapping("/api/tendency")
+    public ResponseEntity<ApiResponse<TendencyResponse>> updateTendency(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody TendencyRequest request) {
+        Tendency tendency = tendencyService.updateTendency(userDetails.getUsername(), request);
+        TendencyResponse response = TendencyResponse.fromEntity(tendency);
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.TENDENCY_UPDATED, response));
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/user/controller/TendencyController.java
+++ b/src/main/java/com/ureca/yoajungserver/user/controller/TendencyController.java
@@ -1,0 +1,47 @@
+package com.ureca.yoajungserver.user.controller;
+
+import com.ureca.yoajungserver.common.ApiResponse;
+import com.ureca.yoajungserver.common.BaseCode;
+import com.ureca.yoajungserver.user.dto.reqeust.TendencyRequest;
+import com.ureca.yoajungserver.user.dto.response.TendencyResponse;
+import com.ureca.yoajungserver.user.entity.Tendency;
+import com.ureca.yoajungserver.user.service.TendencyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TendencyController {
+
+    private final TendencyService tendencyService;
+
+    @GetMapping("/api/tendency/me")
+    public ResponseEntity<ApiResponse<TendencyResponse>> getMyTendency(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Tendency tendency = tendencyService.getMyTendency(userDetails.getUsername());
+        TendencyResponse response = null;
+
+        if (tendency != null) {
+            response = TendencyResponse.fromEntity(tendency);
+        }
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.TENDENCY_FIND_SUCCESS, response));
+    }
+
+    @PostMapping("/api/tendency")
+    public ResponseEntity<ApiResponse<TendencyResponse>> registerTendency(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody TendencyRequest request) {
+
+        Tendency tendency = tendencyService.registerTendency(userDetails.getUsername(), request);
+        TendencyResponse response = TendencyResponse.fromEntity(tendency);
+        return ResponseEntity.ok(ApiResponse.of(BaseCode.STATUS_CREATED, response));
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/user/controller/UserController.java
+++ b/src/main/java/com/ureca/yoajungserver/user/controller/UserController.java
@@ -8,7 +8,6 @@ import com.ureca.yoajungserver.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +22,6 @@ public class UserController {
     @PostMapping("/api/user/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequest request, HttpSession session) {
         userService.signup(request, session);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(BaseCode.USER_SIGNUP_SUCCESS));
+        return ResponseEntity.ok(ApiResponse.ok(BaseCode.USER_LOGIN_SUCCESS));
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/user/controller/UserController.java
+++ b/src/main/java/com/ureca/yoajungserver/user/controller/UserController.java
@@ -22,6 +22,6 @@ public class UserController {
     @PostMapping("/api/user/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequest request, HttpSession session) {
         userService.signup(request, session);
-        return ResponseEntity.ok(ApiResponse.ok(BaseCode.USER_LOGIN_SUCCESS));
+        return ResponseEntity.ok(ApiResponse.ok(BaseCode.USER_SIGNUP_SUCCESS));
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/user/dto/reqeust/TendencyRequest.java
+++ b/src/main/java/com/ureca/yoajungserver/user/dto/reqeust/TendencyRequest.java
@@ -1,0 +1,19 @@
+package com.ureca.yoajungserver.user.dto.reqeust;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TendencyRequest {
+    @Min(value = 0, message = "0 이상")
+    private Integer avgMonthLyDataGB;
+    @Min(value = 0, message = "0 이상")
+    private Integer avgMonthlyVoiceMin;
+
+    private String comment;
+
+    @Min(value = 0, message = "0 이상")
+    private Integer preferencePrice;
+}

--- a/src/main/java/com/ureca/yoajungserver/user/dto/reqeust/TendencyRequest.java
+++ b/src/main/java/com/ureca/yoajungserver/user/dto/reqeust/TendencyRequest.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TendencyRequest {
     @Min(value = 0, message = "0 이상")
-    private Integer avgMonthLyDataGB;
+    private Integer avgMonthlyDataGB;
     @Min(value = 0, message = "0 이상")
     private Integer avgMonthlyVoiceMin;
 

--- a/src/main/java/com/ureca/yoajungserver/user/dto/response/TendencyResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/user/dto/response/TendencyResponse.java
@@ -17,7 +17,7 @@ public class TendencyResponse {
     public static TendencyResponse fromEntity(Tendency tendency) {
         return TendencyResponse.builder()
                 .avgMonthlyDataGB(tendency.getAvgMonthlyDataGB())
-                .avgMonthlyDataGB(tendency.getAvgMonthlyVoiceMin())
+                .avgMonthlyVoiceMin(tendency.getAvgMonthlyVoiceMin())
                 .comment(tendency.getComment())
                 .preferencePrice(tendency.getPreferencePrice())
                 .build();

--- a/src/main/java/com/ureca/yoajungserver/user/dto/response/TendencyResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/user/dto/response/TendencyResponse.java
@@ -1,0 +1,25 @@
+package com.ureca.yoajungserver.user.dto.response;
+
+import com.ureca.yoajungserver.user.entity.Tendency;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class TendencyResponse {
+    private final Integer avgMonthlyDataGB;
+    private final Integer avgMonthlyVoiceMin;
+    private final String comment;
+    private final Integer preferencePrice;
+
+    public static TendencyResponse fromEntity(Tendency tendency) {
+        return TendencyResponse.builder()
+                .avgMonthlyDataGB(tendency.getAvgMonthlyDataGB())
+                .avgMonthlyDataGB(tendency.getAvgMonthlyVoiceMin())
+                .comment(tendency.getComment())
+                .preferencePrice(tendency.getPreferencePrice())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/user/entity/Tendency.java
+++ b/src/main/java/com/ureca/yoajungserver/user/entity/Tendency.java
@@ -42,7 +42,7 @@ public class Tendency extends BaseTimeEntity {
     }
 
     public void updateTendency(TendencyRequest request) {
-        this.avgMonthlyDataGB = request.getAvgMonthLyDataGB();
+        this.avgMonthlyDataGB = request.getAvgMonthlyDataGB();
         this.avgMonthlyVoiceMin = request.getAvgMonthlyVoiceMin();
         this.comment = request.getComment();
         this.preferencePrice = request.getPreferencePrice();

--- a/src/main/java/com/ureca/yoajungserver/user/entity/Tendency.java
+++ b/src/main/java/com/ureca/yoajungserver/user/entity/Tendency.java
@@ -1,6 +1,7 @@
 package com.ureca.yoajungserver.user.entity;
 
 import com.ureca.yoajungserver.common.BaseTimeEntity;
+import com.ureca.yoajungserver.user.dto.reqeust.TendencyRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,5 +39,12 @@ public class Tendency extends BaseTimeEntity {
         this.avgMonthlyVoiceMin = avgMonthlyVoiceMin;
         this.comment = comment;
         this.preferencePrice = preferencePrice;
+    }
+
+    public void updateTendency(TendencyRequest request) {
+        this.avgMonthlyDataGB = request.getAvgMonthLyDataGB();
+        this.avgMonthlyVoiceMin = request.getAvgMonthlyVoiceMin();
+        this.comment = request.getComment();
+        this.preferencePrice = request.getPreferencePrice();
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/user/exception/TendencyAlreadyExistsException.java
+++ b/src/main/java/com/ureca/yoajungserver/user/exception/TendencyAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.ureca.yoajungserver.user.exception;
+
+import com.ureca.yoajungserver.common.BaseCode;
+import com.ureca.yoajungserver.common.exception.BusinessException;
+
+public class TendencyAlreadyExistsException extends BusinessException {
+    public TendencyAlreadyExistsException() {
+        super(BaseCode.TENDENCY_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/user/exception/TendencyNotFoundException.java
+++ b/src/main/java/com/ureca/yoajungserver/user/exception/TendencyNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ureca.yoajungserver.user.exception;
+
+import com.ureca.yoajungserver.common.BaseCode;
+import com.ureca.yoajungserver.common.exception.BusinessException;
+
+public class TendencyNotFoundException extends BusinessException {
+    public TendencyNotFoundException() {
+        super(BaseCode.TENDENCY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/user/repository/TendencyRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/user/repository/TendencyRepository.java
@@ -1,0 +1,11 @@
+package com.ureca.yoajungserver.user.repository;
+
+import com.ureca.yoajungserver.user.entity.Tendency;
+import com.ureca.yoajungserver.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TendencyRepository extends JpaRepository<Tendency, Long> {
+    Optional<Tendency> findByUser(User user);
+}

--- a/src/main/java/com/ureca/yoajungserver/user/service/TendencyService.java
+++ b/src/main/java/com/ureca/yoajungserver/user/service/TendencyService.java
@@ -1,0 +1,12 @@
+package com.ureca.yoajungserver.user.service;
+
+import com.ureca.yoajungserver.user.dto.reqeust.TendencyRequest;
+import com.ureca.yoajungserver.user.entity.Tendency;
+
+public interface TendencyService {
+    Tendency getMyTendency(String email);
+
+    Tendency registerTendency(String email, TendencyRequest request);
+
+    Tendency updateTendency(String email, TendencyRequest request);
+}

--- a/src/main/java/com/ureca/yoajungserver/user/service/TendencyServiceImpl.java
+++ b/src/main/java/com/ureca/yoajungserver/user/service/TendencyServiceImpl.java
@@ -41,7 +41,7 @@ public class TendencyServiceImpl implements TendencyService {
 
         Tendency tendency = Tendency.builder()
                 .user(user)
-                .avgMonthlyDataGB(request.getAvgMonthLyDataGB())
+                .avgMonthlyDataGB(request.getAvgMonthlyDataGB())
                 .avgMonthlyVoiceMin(request.getAvgMonthlyVoiceMin())
                 .comment(request.getComment())
                 .preferencePrice(request.getPreferencePrice())

--- a/src/main/java/com/ureca/yoajungserver/user/service/TendencyServiceImpl.java
+++ b/src/main/java/com/ureca/yoajungserver/user/service/TendencyServiceImpl.java
@@ -1,0 +1,65 @@
+package com.ureca.yoajungserver.user.service;
+
+import com.ureca.yoajungserver.user.dto.reqeust.TendencyRequest;
+import com.ureca.yoajungserver.user.entity.Tendency;
+import com.ureca.yoajungserver.user.entity.User;
+import com.ureca.yoajungserver.user.exception.TendencyAlreadyExistsException;
+import com.ureca.yoajungserver.user.exception.TendencyNotFoundException;
+import com.ureca.yoajungserver.user.exception.UserNotFoundException;
+import com.ureca.yoajungserver.user.repository.TendencyRepository;
+import com.ureca.yoajungserver.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TendencyServiceImpl implements TendencyService {
+    private final TendencyRepository tendencyRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public Tendency getMyTendency(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        return tendencyRepository.findByUser(user).orElse(null);
+    }
+
+    @Override
+    public Tendency registerTendency(String email, TendencyRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+        // 동시성 처리
+        tendencyRepository.findByUser(user).ifPresent(
+                tendency -> {
+                    throw new TendencyAlreadyExistsException();
+                }
+        );
+
+        Tendency tendency = Tendency.builder()
+                .user(user)
+                .avgMonthlyDataGB(request.getAvgMonthLyDataGB())
+                .avgMonthlyVoiceMin(request.getAvgMonthlyVoiceMin())
+                .comment(request.getComment())
+                .preferencePrice(request.getPreferencePrice())
+                .build();
+
+        return tendencyRepository.save(tendency);
+    }
+
+    @Override
+    public Tendency updateTendency(String email, TendencyRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        Tendency tendency = tendencyRepository.findByUser(user)
+                .orElseThrow(TendencyNotFoundException::new);
+
+        tendency.updateTendency(request);
+
+        return tendency;
+    }
+}


### PR DESCRIPTION
## 개요
- 내 성향 정보 API 구현
- 최초 로그인 시 성향 정보 미등록 시 팝업 노출 data == null?

## 변경 사항
- Tendency 도메인
- GET, POST, PUT, Basecode

## 스크린샷
<img width="492" alt="스크린샷 2025-06-10 오전 2 01 37" src="https://github.com/user-attachments/assets/20a0d1ef-fa61-430d-985e-e8e8554327e0" />
<img width="451" alt="스크린샷 2025-06-10 오전 2 01 57" src="https://github.com/user-attachments/assets/9e33a933-8b2e-4f3c-b40c-18fbd6c9a69d" />
<img width="498" alt="스크린샷 2025-06-10 오전 2 04 48" src="https://github.com/user-attachments/assets/c279035f-85f9-4261-82b7-626d5227332d" />
