### PR TITLE
[feat] 요금제 정렬 및 연령대 필터 추가, benefit 조회

### DIFF
--- a/src/main/java/com/ureca/yoajungserver/plan/dto/request/PlanFilterRequest.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/request/PlanFilterRequest.java
@@ -1,6 +1,7 @@
 package com.ureca.yoajungserver.plan.dto.request;
 
 import com.ureca.yoajungserver.plan.entity.PlanCategory;
+import com.ureca.yoajungserver.user.entity.AgeGroup;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,12 @@ import java.util.Set;
 @Builder
 public class PlanFilterRequest {
     private PlanCategory category;
+
+    /** 연령 필터: ALL | TEN_S | TWENTY_S ... */
+    private AgeGroup ageGroup;
+
+    /** 정렬: POPULAR | LOW_PRICE | HIGH_PRICE | DATA */
+    private String sort;
 
     /** 데이터 타입: UNLIMITED | FIXED | THROTTLED | ANY(null) */
     private String dataType;

--- a/src/main/java/com/ureca/yoajungserver/plan/dto/response/PlanFilterResponse.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/response/PlanFilterResponse.java
@@ -5,11 +5,19 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class PlanFilterResponse {
+
+    @Getter
+    @Builder
+    public static class BenefitSummary {
+        private String name;
+        private String description;
+    }
 
     private Long id;
     private String name;
@@ -17,6 +25,7 @@ public class PlanFilterResponse {
     private Integer dataAllowance;
     private Integer speedAfterLimit;
     private Set<String> productNames;
+    private List<BenefitSummary> benefits;
 
     public static PlanFilterResponse from(Plan plan) {
         return PlanFilterResponse.builder()
@@ -25,9 +34,17 @@ public class PlanFilterResponse {
                 .basePrice(plan.getBasePrice())
                 .dataAllowance(plan.getDataAllowance())
                 .speedAfterLimit(plan.getSpeedAfterLimit())
-                .productNames(plan.getPlanProducts().stream()
-                        .map(pp -> pp.getProduct().getName())
-                        .collect(Collectors.toSet()))
+                .productNames(
+                        plan.getPlanProducts().stream()
+                            .map(pp -> pp.getProduct().getName())
+                            .collect(Collectors.toSet()))
+                .benefits(
+                        plan.getPlanBenefits().stream()
+                            .map(pb -> BenefitSummary.builder()
+                                    .name(pb.getBenefit().getName())
+                                    .description(pb.getBenefit().getDescription())
+                                    .build())
+                            .toList())
                 .build();
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/entity/PlanStatistic.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/entity/PlanStatistic.java
@@ -1,0 +1,41 @@
+package com.ureca.yoajungserver.plan.entity;
+
+import com.ureca.yoajungserver.common.BaseTimeEntity;
+import com.ureca.yoajungserver.user.entity.AgeGroup;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanStatistic extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AgeGroup ageGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PlanCategory planCategory;
+
+    @Column(nullable = false)
+    private Long planId;
+
+    @Column(nullable = false)
+    private Long userCount;
+
+    @Builder
+    private PlanStatistic(AgeGroup ageGroup, PlanCategory planCategory, Long planId, Long userCount) {
+        this.ageGroup = ageGroup;
+        this.planCategory = planCategory;
+        this.planId = planId;
+        this.userCount = userCount;
+    }
+}

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/PlanFilterRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/PlanFilterRepository.java
@@ -1,9 +1,12 @@
 package com.ureca.yoajungserver.plan.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ureca.yoajungserver.plan.dto.request.PlanFilterRequest;
 import com.ureca.yoajungserver.plan.entity.*;
+import com.ureca.yoajungserver.user.entity.AgeGroup;
+import com.querydsl.core.types.OrderSpecifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -22,11 +25,22 @@ public class PlanFilterRepository {
         QPlan plan = QPlan.plan;
         QPlanProduct planProduct = QPlanProduct.planProduct;
         QProduct product = QProduct.product;
+        String sort = planFilterRequest.getSort();
+        boolean popularSort = "POPULAR".equalsIgnoreCase(sort);
+        QPlanStatistic stat = popularSort ? QPlanStatistic.planStatistic : null;
+
 
         BooleanBuilder booleanBuilder = new BooleanBuilder(); // 동적 where 절 구성
 
         if(planFilterRequest.getCategory() != null && planFilterRequest.getCategory() != PlanCategory.ALL){
             booleanBuilder.and(plan.planCategory.eq(planFilterRequest.getCategory())); // 카테고리 필터, ALL 이 아닐 때
+        }
+
+        // 연령대 필터  (stat.ageGroup 기준) - 인기순일 때만 적용
+        if (popularSort &&
+            planFilterRequest.getAgeGroup() != null &&
+            planFilterRequest.getAgeGroup() != AgeGroup.ALL) {
+            booleanBuilder.and(stat.ageGroup.eq(planFilterRequest.getAgeGroup()));
         }
 
         // 가격 범위 필터
@@ -54,11 +68,40 @@ public class PlanFilterRepository {
         if (planFilterRequest.getProductNames() != null && !planFilterRequest.getProductNames().isEmpty())
             booleanBuilder.and(product.name.in(planFilterRequest.getProductNames()));
 
-        return queryFactory.selectDistinct(plan)
-                .from(plan)
-                .leftJoin(plan.planProducts, planProduct).fetchJoin()
-                .leftJoin(planProduct.product, product).fetchJoin()
-                .where(booleanBuilder)
-                .fetch();
+        // 정렬 지정
+        OrderSpecifier<?> orderSpec;
+        if ("POPULAR".equalsIgnoreCase(sort)) {
+            orderSpec = null;   // handled via groupBy/max() below
+        } else if ("LOW_PRICE".equalsIgnoreCase(sort)) {
+            orderSpec = plan.basePrice.asc();
+        } else if ("HIGH_PRICE".equalsIgnoreCase(sort)) {
+            orderSpec = plan.basePrice.desc();
+        } else if ("DATA".equalsIgnoreCase(sort)) {
+            orderSpec = plan.dataAllowance.desc();
+        } else {
+            orderSpec = plan.id.asc(); // default
+        }
+
+        JPAQuery<Plan> query;
+
+        if (popularSort) {
+            // ── 인기순: 통계 join, Plan 컬럼만 SELECT, 연관 컬렉션은 이후 LAZY ──
+            query = queryFactory.select(plan)
+                    .from(plan)
+                    .leftJoin(stat).on(stat.planId.eq(plan.id))
+                    .where(booleanBuilder)
+                    .groupBy(plan.id)
+                    .orderBy(stat.userCount.max().desc());
+        } else {
+            // ── 그 외 정렬 ──
+            query = queryFactory.selectDistinct(plan)
+                    .from(plan)
+                    .leftJoin(plan.planProducts, planProduct).fetchJoin()
+                    .leftJoin(planProduct.product, product).fetchJoin()
+                    .where(booleanBuilder)
+                    .orderBy(orderSpec);
+        }
+
+        return query.fetch();
     }
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/PlanStatisticRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/PlanStatisticRepository.java
@@ -1,0 +1,7 @@
+package com.ureca.yoajungserver.plan.repository;
+
+import com.ureca.yoajungserver.plan.entity.PlanStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanStatisticRepository extends JpaRepository<PlanStatistic, Long> {
+}

--- a/src/main/resources/static/plan-test.html
+++ b/src/main/resources/static/plan-test.html
@@ -68,7 +68,7 @@
     document.getElementById('searchBtn').addEventListener('click', fetchPlans);
 
     async function fetchPlans() {
-        // ① 폼 값 수집
+        //  폼 값 수집
         const category   = document.getElementById('category').value;
         const dataType   = document.querySelector('input[name="dataType"]:checked').value;
         const priceRange = document.querySelector('input[name="priceRange"]:checked').value;
@@ -86,7 +86,7 @@
                             .join(',');
         }
 
-        // ② 쿼리스트링 빌드
+        //  쿼리스트링 빌드
         const params = new URLSearchParams();
         params.append('category', category);
         if (dataType)    params.append('dataType', dataType);
@@ -95,11 +95,11 @@
         if (ageGroup) params.append('ageGroup', ageGroup);
         if (sort)     params.append('sort', sort);
 
-        // ③ API 호출
+        //  API 호출
         const res  = await fetch(`/api/plans?${params.toString()}`);
         const json = await res.json();          // {code, message, data}
 
-        // ④ 결과 렌더링
+        //  결과 렌더링
         const ul = document.getElementById('result');
         ul.innerHTML = '';
 
@@ -107,6 +107,15 @@
             const li = document.createElement('li');
             li.textContent = `[${p.name}]  ${p.basePrice.toLocaleString()}원  (${p.dataAllowance >= 9999 ? '무제한' : p.dataAllowance+'GB'})`;
             ul.appendChild(li);
+            if (p.benefits && p.benefits.length) {
+                const benefitsUl = document.createElement('ul');
+                p.benefits.forEach(b => {
+                    const bLi = document.createElement('li');
+                    bLi.textContent = `${b.name} : ${b.description}`;
+                    benefitsUl.appendChild(bLi);
+                });
+                ul.appendChild(benefitsUl);
+            }
         });
     }
 // 연령대 필터는 '인기순'일 때만 표시

--- a/src/main/resources/static/plan-test.html
+++ b/src/main/resources/static/plan-test.html
@@ -8,6 +8,24 @@
 <h1>LG U⁺ 요금제 필터</h1>
 
 <section>
+    <label>정렬:
+      <select id="sort">
+        <option value="POPULAR">인기순</option>
+        <option value="LOW_PRICE">낮은가격순</option>
+        <option value="HIGH_PRICE">높은가격순</option>
+        <option value="DATA">데이터 많은 순</option>
+      </select>
+    </label>
+    <br><br>
+    <fieldset>
+      <legend>연령대</legend>
+      <label><input type="radio" name="ageGroup" value="ALL" checked>전체</label>
+      <label><input type="radio" name="ageGroup" value="TWENTY_S">20대</label>
+      <label><input type="radio" name="ageGroup" value="THIRTY_S">30대</label>
+      <label><input type="radio" name="ageGroup" value="FORTY_S">40대</label>
+      <label><input type="radio" name="ageGroup" value="FIFTY_S">50대</label>
+      <label><input type="radio" name="ageGroup" value="SIXTY_S_PLUS">60대+</label>
+    </fieldset>
     <label>카테고리:
         <select id="category">
             <option value="ALL">전체</option>
@@ -54,6 +72,12 @@
         const category   = document.getElementById('category').value;
         const dataType   = document.querySelector('input[name="dataType"]:checked').value;
         const priceRange = document.querySelector('input[name="priceRange"]:checked').value;
+        const sort     = document.getElementById('sort').value;
+
+        let ageGroup = '';
+        if (sort === 'POPULAR') {
+            ageGroup = document.querySelector('input[name="ageGroup"]:checked').value;
+        }
 
         let productNames = '';
         if (!document.getElementById('noProduct').checked) {
@@ -68,6 +92,8 @@
         if (dataType)    params.append('dataType', dataType);
         if (priceRange)  params.append('priceRange', priceRange);
         if (productNames)  params.append('productNames', productNames);
+        if (ageGroup) params.append('ageGroup', ageGroup);
+        if (sort)     params.append('sort', sort);
 
         // ③ API 호출
         const res  = await fetch(`/api/plans?${params.toString()}`);
@@ -83,6 +109,11 @@
             ul.appendChild(li);
         });
     }
+// 연령대 필터는 '인기순'일 때만 표시
+const ageFieldset = document.querySelector('fieldset legend').parentNode; // first fieldset is ageGroup
+document.getElementById('sort').addEventListener('change', () => {
+    ageFieldset.style.display = (document.getElementById('sort').value === 'POPULAR') ? 'block' : 'none';
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 개요
<!-- 이 PR이 어떤 기능/수정/버그 해결 등을 위한 것인지 간단히 설명해주세요. -->
- 요금제 조회 화면에서 정렬 기능추가, 인기순(연령대 필터), 낮은 가격 순, 높은 가격 순 , 데이터 순
- 조회 시 benefit 정보 조회 되도록 추가
- 테스트 화면에 반영
- 인기순 정렬 시 연령대 별 선택가능 (20대 인기 요금제..등)
- product 선택 시 하나라도 해당되면 조회

## 변경 사항
<!-- 주요 변경 사항을 bullet로 정리해주세요 -->
- PlanStaistic 엔티티 리포지토리 추가
- 테스트 화면 수정
- PlanFilterRepository 수정
- benefit 정보 추가

## 스크린샷 
<img width="413" alt="image" src="https://github.com/user-attachments/assets/dc3f64be-29ab-4f05-b50e-dc3c58ddbd43" />
