### PR TITLE
[feat] 요금제 조회 페이지네이션, 인기순 조회 시 최근 통계 사용

### DIFF
--- a/src/main/java/com/ureca/yoajungserver/plan/dto/request/PlanFilterRequest.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/dto/request/PlanFilterRequest.java
@@ -26,4 +26,7 @@ public class PlanFilterRequest {
 
     /** 선택된 프로덕트 이름 (없으면 필터 미적용) */
     private Set<String> productNames;
+
+    private Integer page;
+    private Integer size;
 }

--- a/src/main/java/com/ureca/yoajungserver/plan/repository/PlanFilterRepository.java
+++ b/src/main/java/com/ureca/yoajungserver/plan/repository/PlanFilterRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 
 import com.ureca.yoajungserver.plan.entity.QPlanBenefit;
@@ -100,6 +101,9 @@ public class PlanFilterRepository {
             orderSpec = plan.id.asc(); // default
         }
 
+        int page = Optional.ofNullable(planFilterRequest.getPage()).orElse(0);
+        int size = Optional.ofNullable(planFilterRequest.getSize()).orElse(9);
+
         JPAQuery<Plan> query;
 
         if (popularSort) {
@@ -114,14 +118,18 @@ public class PlanFilterRepository {
                     )
                     .where(booleanBuilder)
                     .groupBy(plan.id)
-                    .orderBy(stat.userCount.max().desc());
+                    .orderBy(stat.userCount.max().desc())
+                    .offset((long) page * size)
+                    .limit(size);
         } else {
             query = queryFactory.selectDistinct(plan)
                     .from(plan)
                     .leftJoin(plan.planProducts, planProduct).fetchJoin()
                     .leftJoin(planProduct.product, product).fetchJoin()
                     .where(booleanBuilder)
-                    .orderBy(orderSpec);
+                    .orderBy(orderSpec)
+                    .offset((long) page * size)
+                    .limit(size);
         }
 
         return query.fetch();

--- a/src/main/resources/static/plan-test.html
+++ b/src/main/resources/static/plan-test.html
@@ -66,8 +66,14 @@
 <ul id="result"></ul>
 
 <script>
-    let pageIdx = 0;          // current page (0‑based)
+    let pageIdx = 0;
     const PAGE_SIZE = 9;
+
+    document.addEventListener('DOMContentLoaded', () => {
+        ageFieldset.style.display = 'block';
+        pageIdx = 0;
+        fetchPlans(false);
+    });
 
     document.getElementById('searchBtn').addEventListener('click', () => {
         pageIdx = 0;

--- a/src/main/resources/static/plan-test.html
+++ b/src/main/resources/static/plan-test.html
@@ -17,7 +17,7 @@
       </select>
     </label>
     <br><br>
-    <fieldset>
+    <fieldset id="ageFieldset">
       <legend>연령대</legend>
       <label><input type="radio" name="ageGroup" value="ALL" checked>전체</label>
       <label><input type="radio" name="ageGroup" value="TWENTY_S">20대</label>
@@ -59,15 +59,27 @@
         <label><input type="checkbox" name="product" value="바이브">바이브</label>
     </fieldset>
     <button id="searchBtn">검색</button>
+    <button id="moreBtn">더보기</button>
 </section>
 
 <hr>
 <ul id="result"></ul>
 
 <script>
-    document.getElementById('searchBtn').addEventListener('click', fetchPlans);
+    let pageIdx = 0;          // current page (0‑based)
+    const PAGE_SIZE = 9;
 
-    async function fetchPlans() {
+    document.getElementById('searchBtn').addEventListener('click', () => {
+        pageIdx = 0;
+        fetchPlans(false);
+    });
+
+    document.getElementById('moreBtn').addEventListener('click', () => {
+        pageIdx += 1;
+        fetchPlans(true);
+    });
+
+    async function fetchPlans(append = false) {
         //  폼 값 수집
         const category   = document.getElementById('category').value;
         const dataType   = document.querySelector('input[name="dataType"]:checked').value;
@@ -94,6 +106,8 @@
         if (productNames)  params.append('productNames', productNames);
         if (ageGroup) params.append('ageGroup', ageGroup);
         if (sort)     params.append('sort', sort);
+        params.append('page', pageIdx);
+        params.append('size', PAGE_SIZE);
 
         //  API 호출
         const res  = await fetch(`/api/plans?${params.toString()}`);
@@ -101,7 +115,7 @@
 
         //  결과 렌더링
         const ul = document.getElementById('result');
-        ul.innerHTML = '';
+        if (!append) ul.innerHTML = '';
 
         json.data.forEach(p => {
             const li = document.createElement('li');
@@ -119,7 +133,7 @@
         });
     }
 // 연령대 필터는 '인기순'일 때만 표시
-const ageFieldset = document.querySelector('fieldset legend').parentNode; // first fieldset is ageGroup
+const ageFieldset = document.getElementById('ageFieldset');
 document.getElementById('sort').addEventListener('change', () => {
     ageFieldset.style.display = (document.getElementById('sort').value === 'POPULAR') ? 'block' : 'none';
 });


### PR DESCRIPTION
## 개요
<!-- 이 PR이 어떤 기능/수정/버그 해결 등을 위한 것인지 간단히 설명해주세요. -->
- 요금제 조회 페이지에 페이지네이션 적용
- 인기순 조회 시 가장 최근 일자 통계만 반영하도록 수정

## 변경 사항
<!-- 주요 변경 사항을 bullet로 정리해주세요 -->
- 최초 화면에서 인기순으로 전체 요금제 불러오도록 수정
- 페이지네이션 적용
- 인기순 조회 시 planstastic 에서 가장 큰 createDate 의 일자의 통계로 조회
